### PR TITLE
adds argument to onclick method

### DIFF
--- a/jquery.imgcheckbox.js
+++ b/jquery.imgcheckbox.js
@@ -173,9 +173,10 @@
 		}
 		// set up click handler
 		$wrapperElement.click(function() {
-			changeSelection($(this), CHK_TOGGLE, options.addToForm, options.radio, options.canDeselect, $wrapperElement);
+			var el = $(this); 
+			changeSelection(el, CHK_TOGGLE, options.addToForm, options.radio, options.canDeselect, $wrapperElement);
 			if (options.onclick)
-				options.onclick(this);
+				options.onclick(el);
 		});
 
 		/* *** INJECT INTO FORM *** */

--- a/jquery.imgcheckbox.js
+++ b/jquery.imgcheckbox.js
@@ -175,7 +175,7 @@
 		$wrapperElement.click(function() {
 			changeSelection($(this), CHK_TOGGLE, options.addToForm, options.radio, options.canDeselect, $wrapperElement);
 			if (options.onclick)
-				options.onclick();
+				options.onclick(this);
 		});
 
 		/* *** INJECT INTO FORM *** */


### PR DESCRIPTION
a function handling `onclick` events currently does not have any way to tell which image was clicked.  This commit passes the jQuery element that wraps the currently clicked image.  Then we can  have 
```
onclick = function(el) {
    let isChecked = el.hasClass("imgChked"),
         imgElement = el.children('img')[0];
}
```
Then we can do stuff like `el.select()` or `el.deselect()`.

We have access to the image element itself too.  For example, if the image tag has an `id` then we can retrieve it as `imgElement.id`.